### PR TITLE
Review StyleCI rules

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -16,6 +16,8 @@ enabled:
   - nullable_type_declarations
   - phpdoc_add_missing_param_annotation
   - phpdoc_link_to_see
+  - phpdoc_separation
+  - phpdoc_types_null_last
   - short_list_syntax
   - simple_to_complex_string_variable
   - strict_comparison

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -16,7 +16,6 @@ enabled:
   - nullable_type_declarations
   - phpdoc_add_missing_param_annotation
   - phpdoc_link_to_see
-  - phpdoc_separation
   - phpdoc_types_null_last
   - short_list_syntax
   - simple_to_complex_string_variable
@@ -31,3 +30,4 @@ disabled:
   - phpdoc_no_package
   - phpdoc_no_useless_inheritdoc
   - phpdoc_order
+  - phpdoc_separation

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -6,8 +6,10 @@ enabled:
   - concat_with_spaces
   - const_separation
   - const_visibility_required
+  - fully_qualified_strict_types
   - linebreak_after_opening_tag
   - logical_operators
+  - modernize_types_casting
   - multiline_comment_opening_closing
   - no_blank_lines_after_return
   - no_extra_block_blank_lines
@@ -20,6 +22,7 @@ enabled:
   - short_list_syntax
   - simple_to_complex_string_variable
   - strict_comparison
+  - void_return
 
 disabled:
   - align_double_arrow

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -22,7 +22,6 @@ enabled:
   - short_list_syntax
   - simple_to_complex_string_variable
   - strict_comparison
-  - void_return
 
 disabled:
   - align_double_arrow


### PR DESCRIPTION
All risky rules, that we are using, do not seem to be risky at all. Therefore, the risky mode can stay enabled.  
On top of that, new rules have been added. The `phpdoc_separation` rule has been disabled as the style of PHPDoc will change.