### PR TITLE
 PHPUnit 9.3+ style code coverage config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "laravel/socialite": "^4.4|^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5|^9.0",
+        "phpunit/phpunit": "^9.3",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97e109f2c2df68fdecc668498885230f",
+    "content-hash": "d70d52fe53affc869ab07bff3284998c",
     "packages": [
         {
             "name": "doctrine/inflector",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+>
     <testsuites>
         <testsuite name="Unit">
             <directory>./tests/Unit</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
Update the PHPUnit config to stop using deprecated configurations.  
However, because of that, the support of PHPUnit 8.5+ must be dropped.