### PR TITLE
Always use query client arguments instead of building the URL

### DIFF
--- a/src/Providers/SteamProvider.php
+++ b/src/Providers/SteamProvider.php
@@ -83,14 +83,12 @@ class SteamProvider extends AbstractProvider
      */
     protected function getUserByToken($token): array
     {
-        $params = [
-            'key' => $this->clientSecret,
-            'steamids' => $token,
-        ];
-
-        $userUrl = self::USER_INFO_URL . '?' . http_build_query($params);
-
-        $response = $this->getHttpClient()->get($userUrl);
+        $response = $this->getHttpClient()->get(self::USER_INFO_URL, [
+            'query' => [
+                'key' => $this->clientSecret,
+                'steamids' => $token,
+            ],
+        ]);
 
         $user = json_decode($response->getBody()->getContents(), true);
 


### PR DESCRIPTION
Always use query client arguments instead of manually building the URL or instead of using `http_build_query()`.