### PR TITLE
Fix compatibility with Laravel 13

### DIFF
--- a/src/SteamSocialiteProvider.php
+++ b/src/SteamSocialiteProvider.php
@@ -20,7 +20,7 @@ class SteamSocialiteProvider extends ServiceProvider
     {
         $socialite = $this->app->make(Factory::class);
 
-        $socialite->extend('steam', static function ($app) use ($socialite) {
+        $socialite->extend('steam', function ($app) use ($socialite) {
             $config = $app['config']['services.steam'];
 
             return $socialite->buildProvider(SteamProvider::class, $config);


### PR DESCRIPTION
This minor change fixes the error `Cannot bind an instance to a static closure, this will be an error in PHP 9` when using Laravel 13.

This issue is caused because Laravel now binds the manager instance to custom driver closures (see https://github.com/laravel/framework/pull/57173) resulting in an error for static closures.